### PR TITLE
fix: swap snippy container for one without snpEff version issue

### DIFF
--- a/modules/local/snippy.nf
+++ b/modules/local/snippy.nf
@@ -2,9 +2,7 @@ process SNIPPY {
     tag "$sample_name"
     label 'process_medium'
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/snippy:4.6.0--hdfd78af_4' :
-        'quay.io/biocontainers/snippy:4.6.0--hdfd78af_4' }"
+    container "https://depot.galaxyproject.org/singularity/snippy%3A4.6.0--0"
     
     input:
     tuple val(sample_name), file(input)

--- a/modules/local/snippy_amr.nf
+++ b/modules/local/snippy_amr.nf
@@ -4,9 +4,7 @@ process SNIPPY_AMR {
     tag "$sample_name"
     label 'process_medium'
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/snippy:4.6.0--hdfd78af_4' :
-        'quay.io/biocontainers/snippy:4.6.0--hdfd78af_4' }"
+    container "https://depot.galaxyproject.org/singularity/snippy%3A4.6.0--0"
     
     input:
     tuple val(sample_name), path(fastq_paths)

--- a/modules/local/snippy_clean.nf
+++ b/modules/local/snippy_clean.nf
@@ -1,9 +1,7 @@
 process SNIPPY_CLEAN {
     label 'process_low_memory'
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/snippy:4.6.0--hdfd78af_4' :
-        'quay.io/biocontainers/snippy:4.6.0--hdfd78af_4' }"
+    container "https://depot.galaxyproject.org/singularity/snippy%3A4.6.0--0"
 
     input:
     path(full_aln)

--- a/modules/local/snippy_core.nf
+++ b/modules/local/snippy_core.nf
@@ -1,9 +1,7 @@
 process SNIPPY_CORE {
     label 'process_low_memory'
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/snippy:4.6.0--hdfd78af_4' :
-        'quay.io/biocontainers/snippy:4.6.0--hdfd78af_4' }"
+    container "https://depot.galaxyproject.org/singularity/snippy%3A4.6.0--0"
 
     input:
     path(vcf)


### PR DESCRIPTION
Closes #8 
New container has same version of Snippy without snpEff version bug