### PR TITLE
FIX: update paths to samplesheets in test profiles

### DIFF
--- a/conf/test_both.config
+++ b/conf/test_both.config
@@ -16,5 +16,5 @@ params {
     fastq_w_fasta              = true
 
     // Input data
-    input = "https://raw.githubusercontent.com/CDCgov/neissflow/2.1.0/assets/samplesheet_both.csv"
+    input = "https://raw.githubusercontent.com/CDCgov/neissflow/main/assets/samplesheet_both.csv"
 }

--- a/conf/test_fasta.config
+++ b/conf/test_fasta.config
@@ -16,7 +16,7 @@ params {
     only_fasta                 = true
 
     // Input data
-    input = 'https://raw.githubusercontent.com/CDCgov/neissflow/2.1.0/assets/samplesheet_fasta.csv'
+    input = 'https://raw.githubusercontent.com/CDCgov/neissflow/main/assets/samplesheet_fasta.csv'
     
 
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -16,5 +16,5 @@ params {
     only_fastq                 = true
 
     // Input data
-    input = 'https://raw.githubusercontent.com/CDCgov/neissflow/2.1.0/assets/samplesheet.csv'
+    input = 'https://raw.githubusercontent.com/CDCgov/neissflow/main/assets/samplesheet.csv'
 }


### PR DESCRIPTION
github raw user content paths pointed to branch 2.1.0 which no longer exists